### PR TITLE
add option to set usbipd path via workspace settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "uspip-connect",
-  "version": "0.0.3",
+  "name": "usbip-connect",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "uspip-connect",
-      "version": "0.0.3",
+      "name": "usbip-connect",
+      "version": "0.3.0",
+      "license": "MIT",
       "devDependencies": {
         "@types/glob": "^8.1.0",
         "@types/mocha": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,17 @@
         "command": "uspip-connect.Detach",
         "title": "USBIP Detach USB device from WSL"
       }
-    ]
+    ],
+    "configuration":{
+      "title": "USB IP Daemon",
+      "properties": {
+        "usbip-connect.usbipdPath": {
+          "type": "string",
+          "default": "upsipd.exe",
+          "description": "absolute path to usbipd.exe"
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run package",


### PR DESCRIPTION
as usbipd.exe is only available when the system path is set accordingly or when the default terminal is powershell or something other windows related, this PR allows to set an absolute path to usbipd.exe in order to address that.